### PR TITLE
[김여진] 1주차 문제 풀이 제출합니다.

### DIFF
--- a/김여진/[Lv1]나누어_떨어지는_숫자_배열.js
+++ b/김여진/[Lv1]나누어_떨어지는_숫자_배열.js
@@ -1,9 +1,9 @@
 // 문제 접근
 // 1. arr의 각 요소를 divisor로 나눠 나머지가 0인 것만 필터링하고 오름차순으로 정렬
 // 2. 요소가 없으면 [-1] 반환
-// 시간 복잡도 O(n) - 배열의 길이만큼 계산
+// 시간 복잡도 O(nlogn) - 배열의 길이만큼 계산
 
 function solution(arr, divisor) {
-  const result = arr.filter(x=>!(x%divisor)).sort((a,b)=>a-b);
-  return result.length>0 ? result : [-1];
+  const result = arr.filter((x) => !(x % divisor)).sort((a, b) => a - b);
+  return result.length > 0 ? result : [-1];
 }

--- a/김여진/[Lv1]나누어_떨어지는_숫자_배열.js
+++ b/김여진/[Lv1]나누어_떨어지는_숫자_배열.js
@@ -1,0 +1,9 @@
+// 문제 접근
+// 1. arr의 각 요소를 divisor로 나눠 나머지가 0인 것만 필터링하고 오름차순으로 정렬
+// 2. 요소가 없으면 [-1] 반환
+// 시간 복잡도 O(n) - 배열의 길이만큼 계산
+
+function solution(arr, divisor) {
+  const result = arr.filter(x=>!(x%divisor)).sort((a,b)=>a-b);
+  return result.length>0 ? result : [-1];
+}

--- a/김여진/[Lv2]n^2_배열_자르기.js
+++ b/김여진/[Lv2]n^2_배열_자르기.js
@@ -1,0 +1,9 @@
+// 문제 접근
+// 1. 각 셀은 행인덱스+1,열인덱스+1 중 최댓값으로 결정됨 
+// 2. 일차원 배열의 인덱스 left, rignt를 변환하면 각 셀의 값은 max(Math.floor(left/n)+1,left%n+1)
+// 3. left~right까지 1씩 증가시키며 각 셀 계산해 배열에 넣으면 됨
+// 시간 복잡도 O(right - left + 1) - 배열의 길이만큼 계산
+
+function solution(n, left, right) {
+  return Array.from({length:right-left+1},(_,i)=>Math.max(Math.floor((left+i)/n), (left+i)%n+1));
+}

--- a/김여진/[Lv2]n^2_배열_자르기.js
+++ b/김여진/[Lv2]n^2_배열_자르기.js
@@ -1,9 +1,11 @@
 // 문제 접근
-// 1. 각 셀은 행인덱스+1,열인덱스+1 중 최댓값으로 결정됨 
+// 1. 각 셀은 행인덱스+1,열인덱스+1 중 최댓값으로 결정됨
 // 2. 일차원 배열의 인덱스 left, rignt를 변환하면 각 셀의 값은 max(Math.floor(left/n)+1,left%n+1)
 // 3. left~right까지 1씩 증가시키며 각 셀 계산해 배열에 넣으면 됨
 // 시간 복잡도 O(right - left + 1) - 배열의 길이만큼 계산
 
 function solution(n, left, right) {
-  return Array.from({length:right-left+1},(_,i)=>Math.max(Math.floor((left+i)/n)+1, (left+i)%n+1));
+  return Array.from({ length: right - left + 1 }, (_, i) =>
+    Math.max(Math.floor((left + i) / n) + 1, ((left + i) % n) + 1)
+  );
 }

--- a/김여진/[Lv2]n^2_배열_자르기.js
+++ b/김여진/[Lv2]n^2_배열_자르기.js
@@ -5,5 +5,5 @@
 // 시간 복잡도 O(right - left + 1) - 배열의 길이만큼 계산
 
 function solution(n, left, right) {
-  return Array.from({length:right-left+1},(_,i)=>Math.max(Math.floor((left+i)/n), (left+i)%n+1));
+  return Array.from({length:right-left+1},(_,i)=>Math.max(Math.floor((left+i)/n)+1, (left+i)%n+1));
 }

--- a/김여진/[Lv2]배열_자르기.js
+++ b/김여진/[Lv2]배열_자르기.js
@@ -1,0 +1,9 @@
+// 문제 접근
+// 1. 각 셀은 행인덱스+1,열인덱스+1 중 최댓값으로 결정됨 
+// 2. 일차원 배열의 인덱스 left, rignt를 변환하면 각 셀의 값은 max(Math.floor(left/n)+1,left%n+1)
+// 3. left~right까지 1씩 증가시키며 각 셀 계산해 배열에 넣으면 됨
+// 시간 복잡도 O(right - left + 1) - 배열의 길이만큼 계산
+
+function solution(n, left, right) {
+  return Array.from({length:right-left+1},(_,i)=>Math.max(Math.floor((left+i)/n), (left+i)%n+1));
+}

--- a/김여진/[Lv2]배열_자르기.js
+++ b/김여진/[Lv2]배열_자르기.js
@@ -1,9 +1,0 @@
-// 문제 접근
-// 1. 각 셀은 행인덱스+1,열인덱스+1 중 최댓값으로 결정됨 
-// 2. 일차원 배열의 인덱스 left, rignt를 변환하면 각 셀의 값은 max(Math.floor(left/n)+1,left%n+1)
-// 3. left~right까지 1씩 증가시키며 각 셀 계산해 배열에 넣으면 됨
-// 시간 복잡도 O(right - left + 1) - 배열의 길이만큼 계산
-
-function solution(n, left, right) {
-  return Array.from({length:right-left+1},(_,i)=>Math.max(Math.floor((left+i)/n), (left+i)%n+1));
-}

--- a/김여진/[Lv2]스킬트리.js
+++ b/김여진/[Lv2]스킬트리.js
@@ -1,15 +1,15 @@
 // 문제 접근
-// 1. skill_trees의 요소에서 skill에 있는 것만 필터링 
+// 1. skill_trees의 요소에서 skill에 있는 것만 필터링
 // 2. 그것이 skill의 시작과 동일한지 검사해 같으면 count
 // 시간 복잡도 O(m*n) - skill_trees길이 m * 각 요소의 길이 n
 
-function solution(skill, skill_trees){
+function solution(skill, skill_trees) {
   let answer = 0;
 
-  for (const tree of skill_trees){
-    const fillteredTree = [...tree].filter(c=>skill.includes(c)).join('');
-    if(fillteredTree===skill.slice(0,fillteredTree.length)) answer++;
+  for (const tree of skill_trees) {
+    const fillteredTree = [...tree].filter((c) => skill.includes(c)).join("");
+    if (fillteredTree === skill.slice(0, fillteredTree.length)) answer++;
   }
-   
+
   return answer;
 }

--- a/김여진/[Lv2]스킬트리.js
+++ b/김여진/[Lv2]스킬트리.js
@@ -1,0 +1,15 @@
+// 문제 접근
+// 1. skill_trees의 요소에서 skill에 있는 것만 필터링 
+// 2. 그것이 skill의 시작과 동일한지 검사해 같으면 count
+// 시간 복잡도 O(m*n) - skill_trees길이 m * 각 요소의 길이 n
+
+function solution(skill, skill_trees){
+  let answer = 0;
+
+  for (const tree of skill_trees){
+    const fillteredTree = [...tree].filter(c=>skill.includes(c)).join('');
+    if(fillteredTree===skill.slice(0,fillteredTree.length)) answer++;
+  }
+   
+  return answer;
+}

--- a/김여진/[Silver3]두_개의_배열.js
+++ b/김여진/[Silver3]두_개의_배열.js
@@ -8,7 +8,10 @@ const findCloset = (arr, target) => {
   let left = 0;
   let right = arr.length - 1;
 
-  while(left<right){
+  if (target<=arr[left]) return arr[left];
+  if (target>=arr[right]) return arr[right];
+
+  while (left < right) {
     const mid = Math.floor((left + right) / 2);
     if (arr[mid] === target) {
       return arr[mid];
@@ -18,31 +21,29 @@ const findCloset = (arr, target) => {
       right = mid;
     }
   }
-  if(left===0) return arr[left];
-  
   return Math.abs(arr[left] - target) < Math.abs(arr[left - 1] - target)
-  ? arr[left]
-  : arr[left - 1];
+    ? arr[left]
+    : arr[left - 1];
+};
+
+const fs = require("fs");
+const filePath = process.platform === "linux" ? "/dev/stdin" : "example.txt";
+const input = fs.readFileSync(filePath).toString().trim().split("\n");
+
+const testCaseCnt = Number(input[0]);
+const results = [];
+
+let index = 1;
+for (let t = 0; t < testCaseCnt; t++) {
+  index++; //길이는 필요 없음
+  const A = input[index++].split(" ").map(Number);
+  const B = input[index++]
+    .split(" ")
+    .map(Number)
+    .sort((a, b) => a - b);
+
+  results.push(A.reduce((acc, a) => acc + findCloset(B, a), 0));
 }
 
-const readline = require('readline');
-const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-});
-const input=[];
-rl.on('line',(line)=>input.push(line))
-  .on('close',()=>{
-    const testCaseCnt = Number(input[0]);
-    const results = [];
+results.forEach((result) => console.log(result));
 
-    let index = 1;
-    for(let t=0; t<testCaseCnt; t++){
-      index++; //길이는 필요 없음
-      const A = input[index++].split(' ').map(Number);
-      const B = input[index++].split(' ').map(Number).sort((a,b)=>a-b);
-
-      results.push(A.reduce((acc,a)=>acc+findCloset(B,a),0));
-    }
-    results.forEach((result) => console.log(result));
-})

--- a/김여진/[Silver3]두_개의_배열.js
+++ b/김여진/[Silver3]두_개의_배열.js
@@ -1,0 +1,48 @@
+// 문제 접근
+// 1. 첫째줄에 있는 테스트케이스 수만큼 줄 읽기 반복
+// 2. B는 정렬해서 A의 각 요소별로 이진 탐색해 가까운 값 구함
+// 2. 새 배열 값의 합 구함
+// 시간 복잡도 O(t*mlogn)) - 테스트 케이스 수만큼, A배열 길이만큼 B배열 이진 탐색
+
+const findCloset = (arr, target) => {
+  let left = 0;
+  let right = arr.length - 1;
+
+  while(left<right){
+    const mid = Math.floor((left + right) / 2);
+    if (arr[mid] === target) {
+      return arr[mid];
+    } else if (arr[mid] < target) {
+      left = mid + 1;
+    } else {
+      right = mid;
+    }
+  }
+  if(left===0) return arr[left];
+  
+  return Math.abs(arr[left] - target) < Math.abs(arr[left - 1] - target)
+  ? arr[left]
+  : arr[left - 1];
+}
+
+const readline = require('readline');
+const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+});
+const input=[];
+rl.on('line',(line)=>input.push(line))
+  .on('close',()=>{
+    const testCaseCnt = Number(input[0]);
+    const results = [];
+
+    let index = 1;
+    for(let t=0; t<testCaseCnt; t++){
+      index++; //길이는 필요 없음
+      const A = input[index++].split(' ').map(Number);
+      const B = input[index++].split(' ').map(Number).sort((a,b)=>a-b);
+
+      results.push(A.reduce((acc,a)=>acc+findCloset(B,a),0));
+    }
+    results.forEach((result) => console.log(result));
+})


### PR DESCRIPTION
## 💡 풀이한 문제

- [스킬트리](https://school.programmers.co.kr/learn/courses/30/lessons/49993)
- [두 개의 배열](https://www.acmicpc.net/problem/17124)
- [n^2 배열 자르기](https://school.programmers.co.kr/learn/courses/30/lessons/87390)
- [나누어 떨어지는 숫자 배열](https://school.programmers.co.kr/learn/courses/30/lessons/12910)

## 📌 접근 방식

1️⃣ 스킬트리
skill_trees의 요소를 순회하며 각 요소를 배열로 만들어 skill에 있는 문자를 필터링한 후 다시 문자열로 이었습니다. 
그 문자열과 그 문자열길이만큼 자른 skill이 동일하면 count했어요.

2️⃣ 두 개의 배열
A, B 배열을 모두 순회했더니 시간 초과가 떠서 B배열을 오름차순 정렬해서 이진 탐색을 했습니다. 그래서 시간 복잡도가 O(t*a*b) -> O(t*(blogb+alogb))로 바뀌었어요. (t:테스트케이스 수, a:A배열 길이, b:B배열 길이)

3️⃣ n^2 배열 자르기
각 셀이 행인덱스+1,열인덱스+1 중 최댓값으로 결정된다는 규칙을 발견했어요.
그럼 일차원 배열에선 인덱스 left가 들어왔을때 셀의 값은 Math.max(`Math.floor((left/n)+1)`, `(left%n)+1`) 이 될것이고
right-left+1 길이의 배열을 만들어 각 요소에 Math.max(`Math.floor((left+index)/n+1)`, `(left+index)%n+1`)을 넣었어요.

4️⃣ 나누어 떨어지는 숫자 배열
arr의 각 요소를 divisor로 나눠 나머지가 0인 것만 필터링하고 오름차순으로 정렬했어요.
그리고 결과 배열의 길이가 0이면 [-1]을 반환했어요.

## 🔑 고민한 부분

`두 개의 배열` 문제에서 문자열로 주어진 테스트케이스를 읽는 방법이 생각나지 않아 당황했어요. 그리고 시간 초과가 떠서 2차 당황,,,

테스트 케이스가 여러개이고 A배열을 순회하며 각 요소와 비슷한 B배열의 요소를 찾기 위해 또 B 배열을 순회해서 시간복잡도가 O(t*a*b)가 나오더라고요. 시간복잡도를 생각하지 않고 작성해서 문제가 생겼어요.

=> B배열을 정렬한 후 중간값과 비교하며 비교 범위를 줄일 수 있는 이진 탐색을 사용해 시간 복잡도를 줄였어요. 

B배열을 정렬하는데 O(blogb) + A의 각 요소에 대해 B 배열에서 가까운 값을 찾는데 O(alogb) 시간이 필요해요.

B 배열 탐색 시간이 `선형 탐색`에서 `로그 탐색`으로 개선됐다고 표현할 수 있어요.

예를 들어 b가 1000이면 선형 탐색은 1000번 비교해야하지만, 로그 탐색은 약 10번(log2(1000))만 비교하면 돼요. 탐색 횟수가 100배정도 감소하는 거죠. 
이렇게 생각하니 시간복잡도 줄이기엔 적절한 탐색 방법이 정말 중요한 것 같아요.

## 🤔 궁금한 점

