### PR TITLE
[김여진] 3주차 문제 풀이 제출합니다.

### DIFF
--- a/김여진/week3/[Lv1] 같은 숫자는 싫어.js
+++ b/김여진/week3/[Lv1] 같은 숫자는 싫어.js
@@ -1,0 +1,8 @@
+// 문제 접근
+// 1. arr을 filter로 순회하며 다음 요소와 같으면 제외
+// 시간 복잡도 O(n)
+
+function solution(arr) {
+  return arr.filter((v,i)=>v!==arr[i+1]);
+}
+

--- a/김여진/week3/[Lv1] 크레인 인형뽑기 게임.js
+++ b/김여진/week3/[Lv1] 크레인 인형뽑기 게임.js
@@ -1,0 +1,33 @@
+// 문제 접근
+// 1. 옮긴 인형을 담는 배열 s 생성
+// 2. moves 배열을 순회하며 board[board.length-1][moves[i]-1]에 값이 있으면 s에 넣음, 그리고 그 자리를 0으로 바꿈
+// board[0][moves[i]-1] 까지 검사했는데 모두 0이면 넘어감
+// 3. s에 추가할때 이전 인형이 같은 인형이면 없애고 answer+2
+// 시간 복잡도 O(n * m) - moves.length(n), board.length(m)
+
+function solution(board, moves) {
+  let answer = 0;
+  const s = [];
+
+  for (const move of moves){
+    const col = move - 1;
+    for (let row = 0; row < board.length; row++) {
+      if (board[row][col] !== 0) {
+        // 인형 집기
+        const doll = board[row][col];
+        board[row][col] = 0; 
+
+        // s 검사
+        if(s[s.length - 1] === doll){
+          s.pop();
+          answer += 2; 
+        } else {
+          s.push(doll); 
+        } 
+        break;
+      }
+    }
+  }
+  return answer;
+}
+

--- a/김여진/week3/[Lv2] 다리를 지나는 트럭.js
+++ b/김여진/week3/[Lv2] 다리를 지나는 트럭.js
@@ -7,7 +7,7 @@
 // 큐의 front 트럭 나갈 시간이 시간과 같으면 뺌
 // 다리에 올라가있는 무게 + 트럭의 무게가 최대 무게 이하이면 트럭 올리고, 아니면 큐의 front 트럭이 빠지는 시간으로 시간을 업데이트
 // 5. 최종 시간을 리턴 
-// 시간 복잡도 O(nlogn)
+// 시간 복잡도 O(n)
 
 function solution(bridge_length, weight, truck_weights) {
   let time = 0;

--- a/김여진/week3/[Lv2] 다리를 지나는 트럭.js
+++ b/김여진/week3/[Lv2] 다리를 지나는 트럭.js
@@ -1,0 +1,30 @@
+// 문제 접근
+// 1. 트럭의 무게 합이 weight를 넘지 않으면 다리에 최대 bridge_length개 올라갈 수 있음
+// 2. 하나의 트럭이 다리를 건너는 시간은 bridge_length초
+
+// 3. [트럭의 무게(truck_weights[i]), 나갈 시간(time+bridge_length)]을 담아 다리 위의 트럭을 선형 큐 형태로 만듦 - 불필요한 시간 카운트 줄임
+// 4. 다리 위에 트럭이 있을 동안
+// 큐의 front 트럭 나갈 시간이 시간과 같으면 뺌
+// 다리에 올라가있는 무게 + 트럭의 무게가 최대 무게 이하이면 트럭 올리고, 아니면 큐의 front 트럭이 빠지는 시간으로 시간을 업데이트
+// 5. 최종 시간을 리턴 
+// 시간 복잡도 O(nlogn)
+
+function solution(bridge_length, weight, truck_weights) {
+  let time = 0;
+  let bridge_weight = 0;
+  const q = [[0,0]];
+
+  while(q.length > 0){
+    if(q[0][1] === time) bridge_weight -= q.shift()[0];
+
+    if(bridge_weight + truck_weights[0] <= weight){
+      bridge_weight += truck_weights[0];
+      q.push([truck_weights.shift(), time + bridge_length]);
+    }else{
+      if(q[0]) time = q[0][1] - 1;
+    }
+
+    time++;
+  }
+  return time;
+}

--- a/김여진/week3/[Silver1] 회전초밥.js
+++ b/김여진/week3/[Silver1] 회전초밥.js
@@ -1,0 +1,46 @@
+// 문제 접근
+// 시간 초과
+// 1. 손님 번호를 인덱스로 하는 선호 초밥 종류를 담은 배열을 만든다.
+// 2. 요리되는 초밥을 손님 번호가 작은 순으로 확인해 없애고 result 배열로 손님 번호 인덱스에 각 손님이 먹은 초밥 개수를 기록한다.
+// 시간 복잡도 O(m * k) - 요리된 초밥 수(m), 손님 초밥 목록 길이 합(k)
+
+// 다시 접근
+// 1. 초밥에 손님 리스트를 매핑한 Map을 생성해 모든 손님을 확인하지 않고, 초밥으로 선호 손님만 조회
+// 시간 복잡도 O(k + m * 평균 손님 수) - 초밥, 손님 매핑에 O(K), 각 초밥에 대해 해당 손님 리스트 순회 O(m × 평균 손님 수)
+
+const fs = require('fs');
+const filePath = process.platform === 'linux' ? '/dev/stdin' : 'example.txt';
+const input = fs.readFileSync(filePath).toString().trim().split('\n');
+
+const customerCnt = Number(input[0].split(' ')[0]);
+const cookedSushis = input[input.length-1].split(' ').map(Number);
+const sushiToCustomers = new Map();
+const customers = [];
+const results = Array(customerCnt).fill(0);
+
+// 각 손님의 선호 초밥 목록을 Set으로 저장, 초밥에 손님 목록을 매핑 - 해시테이블 사용해 빠르게 검색하기 위해 
+for (let i = 1; i <= customerCnt; i++) {
+  const [, ...sushis] = input[i].split(' ').map(Number);
+  customers.push(new Set(sushis)); 
+  for(const sushi of sushis){
+      sushiToCustomers.has(sushi) 
+          ? sushiToCustomers.get(sushi).push(i-1)
+          : sushiToCustomers.set(sushi, [i-1]);
+  }
+}
+
+// 요리된 초밥 처리
+for (const cookedSushi of cookedSushis){
+  if(sushiToCustomers.has(cookedSushi)){
+      const customerList = sushiToCustomers.get(cookedSushi);
+      for(const cIdx of customerList){
+          if(customers[cIdx].has(cookedSushi)){
+              customers[cIdx].delete(cookedSushi);
+              results[cIdx]++;
+              break;
+          }
+      }
+  }
+}
+
+console.log(results.join(' '));


### PR DESCRIPTION
## 💡 풀이한 문제

- [다리를 지나는 트럭](https://school.programmers.co.kr/learn/courses/30/lessons/42583)
- [크레인 인형뽑기 게임](https://school.programmers.co.kr/learn/courses/30/lessons/64061)
- [회전초밥](https://www.acmicpc.net/problem/28107)
- [같은 숫자는 싫어](https://school.programmers.co.kr/learn/courses/30/lessons/12906)

## 📌 접근 방식

### 1️⃣ 다리를 지나는 트럭

다리 위 트럭들을 큐 구조로 선입선출을 한다는 생각은 했으나.
처음엔 bridge_length만큼의 0으로 채워진 배열을 만들어 truck_weights[i]를 넣으며 트럭이 다리 위에 있는 동안은 초를 계속 증가시키려 했어요.

그런데 입출력 예에서 bridge_length: 100, weight: 100, truck_weights: [10]
이런식으로 bridge_length가 길지만 트럭이 적을때는 불필요하게 0을 빼며 초를 카운트하는게 비효율적이라 생각했고 
큐에 `[무게,지나가는 데 걸리는 시간]` 이렇게 배열을 넣어 사용하여 불필요한 시간 카운트를 줄였어요.

큐에 추가할 트럭이 없는 경우(무게가 넘어서) front에 있는 요소의 `지나가는 데 걸리는 시간 - 1` 만큼 time을 업데이트하고 마지막에 time + 1을 해줬어요.

이렇게 해서 트럭이 빠지지 않는 경우엔 불필요한 연산을 줄였어요.

### 2️⃣ 크레인 인형뽑기 게임

옮긴 인형을 담는 배열을 생성하여
moves 배열을 순회하며 board[board.length-1 ~ 0][moves[i]-1] 까지 검사해 0이 아니면 그 요소를 빼(0으로 초기화) 생성해둔 배열의 이전 요소와 비교하고 넣었어요.
만약 모두 0이면 모든 행 순회를 멈추고 다음 moves 요소를 검사해요.

### 3️⃣ 회전초밥

손님 번호를 인덱스로 하는 선호 초밥 종류를 담은 배열을 만들고
요리되는 초밥을 손님 번호가 작은 순으로 확인해 없애고 result 배열로 손님 번호 인덱스에 각 손님이 먹은 초밥 개수를 기록했어요.

그런데 이렇게 하면 모든 손님과 모든 초밥을 순회하며 초밥을 처리해야해 시간 초과가 떴어요. 
그래서 전체적인 컨셉은 유지하고 초밥을 기준으로 해당 초밥을 선호하는 손님 리스트를 매핑해서 초밥 종류로 손님을 찾을때 불필요한 연산을 줄였어요. 

### 4️⃣ 같은 숫자는 싫어

arr을 filter로 순회하며 다음 요소와 같으면 제외했어요.

## 🔑 고민한 부분

###  1️⃣ 다리를 지나는 트럭

자료구조를 개념적으로 학습하며 하나의 노드엔 하나의 원시값이 들어가야 한다고 생각해, 배열을 넣을 수 있다는 생각을 하는데 조금 오래걸렸어요. 

###  3️⃣ 회전초밥

문제를 풀면서 배열을 불필요하게 순회하는 느낌이 있었는데 역시나 시간 초과가 떴어요.

최종적으로 초밥을 기준으로 손님의 선호 초밥 목록을 조회하니까 초밥종류를 키로 하고, 해당 초밥을 선호하는 손님 리스트를 값으로 하는 map을 생성해 초밥을 선호하는 손님을 빠르게 찾을 수 있게 했어요.

그러니 시간 복잡도가 
요리된 초밥 수(m), 손님 선호 초밥 목록 길이 합(k) 이라고 할때 
O(m * k) -> O(k + m * 평균 손님 수)
로 줄었어요.

## 🤔 궁금한 점