### PR TITLE
[조병찬] 7주차 문제 풀이 제출합니다.

### DIFF
--- a/조병찬/week7/[Lv3] 네트워크.js
+++ b/조병찬/week7/[Lv3] 네트워크.js
@@ -1,0 +1,34 @@
+// 문제 접근
+// 1. bfs를 통해 탐색한다.
+// 2. 방문한 노드는 visited 배열을 통해 체크
+// 3. bfs를 통해 computer의 값이 1이고 방문하지 않은 곳이면 방문
+// 4. bfs를 통해 방문한 노드의 개수를 반환
+
+function solution(n, computers) {
+  let answer = 0;
+  let visited = Array.from({ length: n }, () => false);
+
+  const bfs = (start) => {
+    let queue = [start];
+    visited[start] = true;
+
+    while (queue.length > 0) {
+      const node = queue.shift();
+      for (let i = 0; i < n; i++) {
+        if (computers[node][i] === 1 && !visited[i]) {
+          visited[i] = true;
+          queue.push(i);
+        }
+      }
+    }
+  };
+
+  for (let i = 0; i < n; i++) {
+    if (!visited[i]) {
+      bfs(i);
+      answer++;
+    }
+  }
+
+  return answer;
+}

--- a/조병찬/week7/[Lv3] 여행경로.js
+++ b/조병찬/week7/[Lv3] 여행경로.js
@@ -1,0 +1,29 @@
+// 문제 접근
+// 1. ICN을 초기값으로 시작해 dfs를 통해 탐색
+// 2. tickets에서 요소의 0번째가 현재 공항과 일치하면 해당 티켓을 사용
+// 3. 사용한 티켓은 splice를 통해 제거하고 제거하고자 하는 배열의 첫번째 요소로 dfs
+// 4. tickets를 모두 돌아 결국 다 제거되면 answer에 push
+// 5. answer를 sort한 후 가장 앞에 있는 요소를 반환
+
+function solution(tickets) {
+  let answer = [];
+
+  const dfs = (airport, tickets, path) => {
+    let newPath = [...path, airport];
+
+    if (tickets.length === 0) {
+      answer.push(newPath);
+    } else {
+      tickets.map((ticket, index) => {
+        if (ticket[0] === airport) {
+          let copyTicket = [...tickets];
+          const [[from, to]] = copyTicket.splice(index, 1);
+          dfs(to, copyTicket, newPath);
+        }
+      });
+    }
+  };
+
+  dfs("ICN", tickets, []);
+  return answer.sort()[0];
+}

--- a/조병찬/week7/[Silver2] 유기농 배추.js
+++ b/조병찬/week7/[Silver2] 유기농 배추.js
@@ -1,0 +1,61 @@
+// 문제 접근
+// 1. 테스트케이스별로 순회하며 배추밭을 만들어야함
+// 2. 주어진 input 값을 통해 map에 배추를 심음
+// 3. bfs를 통해 배추를 심은 좌표를 탐색하며 방문하지 않은 배추를 찾아 방문처리
+// 4. 배추밭을 순회하며 1이고 방문하지 않은 곳에 지렁이를 풀고 bfs를 실행
+// 5. 지렁이의 수를 출력
+
+const fs = require("fs");
+const filePath = process.platform === "linux" ? "/dev/stdin" : "example.txt";
+const input = fs.readFileSync(filePath).toString().trim().split("\n");
+
+const testCase = parseInt(input[0]);
+let currentLine = 1;
+
+for (let t = 0; t < testCase; t++) {
+  let worm = 0;
+
+  const [col, row, cabbage] = input[currentLine].split(" ").map(Number);
+  const map = Array.from({ length: row }, () => Array(col).fill(0));
+  const visited = Array.from({ length: row }, () => Array(col).fill(false));
+
+  for (let j = 0; j < cabbage; j++) {
+    const [x, y] = input[currentLine + 1 + j].split(" ").map(Number);
+    map[y][x] = 1;
+  }
+
+  currentLine += cabbage + 1;
+
+  const bfs = (x, y) => {
+    const queue = [[x, y]];
+    visited[x][y] = true;
+
+    while (queue.length > 0) {
+      const [x, y] = queue.shift();
+      const dx = [-1, 1, 0, 0];
+      const dy = [0, 0, -1, 1];
+
+      for (let i = 0; i < 4; i++) {
+        const nx = x + dx[i];
+        const ny = y + dy[i];
+
+        if (nx < 0 || ny < 0 || nx >= row || ny >= col) continue;
+        if (map[nx][ny] === 0 || visited[nx][ny]) continue;
+
+        visited[nx][ny] = true;
+        queue.push([nx, ny]);
+      }
+    }
+  };
+
+  for (let i = 0; i < row; i++) {
+    for (let j = 0; j < col; j++) {
+      if (map[i][j] === 1 && !visited[i][j]) {
+        worm++;
+        bfs(i, j);
+      }
+    }
+  }
+
+  console.log(worm);
+}

--- a/조병찬/week7/[Silver4] 점프왕 쩰리.js
+++ b/조병찬/week7/[Silver4] 점프왕 쩰리.js
@@ -1,0 +1,50 @@
+// 문제 접근
+// 1. 각 좌표에 방문 여부를 체크해야함
+// 2. 초기값은 0,0에서 시작하고 방문처리로 시작
+// 3. bfs를 통해 각 좌표의 값을 가져와서 다음 좌표를 계산
+// 4. 현재 x, y 좌표에서 jump를 더한 값이 맵 안에 있고 방문하지 않았다면 방문처리하고 큐에 삽입
+// 5. 최종 끝에 도달하면 bfs는 참인데, 참이라면 HaruHaru를 반환하고 아니라면 Hing을 반환
+
+const fs = require("fs");
+const filePath = process.platform === "linux" ? "/dev/stdin" : "example.txt";
+const input = fs.readFileSync(filePath).toString().trim().split("\n");
+
+const n = parseInt(input[0]);
+const map = input.slice(1).map((v) => v.split(" ").map(Number));
+
+function solution(n, map) {
+  let visited = Array.from({ length: n }, () => Array(n).fill(false));
+
+  const bfs = () => {
+    let queue = [[0, 0]];
+    visited[0][0] = true;
+
+    while (queue.length > 0) {
+      const [x, y] = queue.shift();
+      const jump = map[x][y];
+
+      if (x === n - 1 && y === n - 1) return true;
+      if (jump === 0) continue;
+
+      const nx = x + jump;
+      const ny = y + jump;
+
+      if (nx < n && !visited[nx][y]) {
+        visited[nx][y] = true;
+        queue.push([nx, y]);
+      }
+      if (ny < n && !visited[x][ny]) {
+        visited[x][ny] = true;
+        queue.push([x, ny]);
+      }
+    }
+  };
+
+  return isPossibleSuccess(bfs());
+}
+
+function isPossibleSuccess(possible) {
+  return possible ? "HaruHaru" : "Hing";
+}
+
+console.log(solution(n, map));


### PR DESCRIPTION
## 💡 풀이한 문제

- [네트워크](https://school.programmers.co.kr/learn/courses/30/lessons/43162)
- [여행경로](https://school.programmers.co.kr/learn/courses/30/lessons/43164)
- [유기농 배추](https://www.acmicpc.net/problem/1012)
- [점프왕 쩰리](https://www.acmicpc.net/problem/16173)

## 📌 접근 방식

### 1️⃣ 네트워크

BFS를 연습하기 좋은 문제인 것 같아요. 
bfs를 통해 탐색을 시작했어요. 방문한 노드는 `visited`를 통해 체크해줬어요.
탐색을 진행하다가 computer의 값이 1이고 방문하지 않은 곳일 경우에 방문처리를 해줘요. 
n만큼 순회를 하며 방문하지 않은 곳이면 bfs 탐색을 진행했어요.

### 2️⃣ 여행경로

테스트 케이스를 골똘히 쳐다봤던 문제에요. 배열 안에 있는 0번째 인덱스로 출발하고 도착지점을 통해 다시 dfs를 진행해야 하는 문제였어요.
`ICN`을 초기값으로 시작해 dfs 탐색을 했어요. 
`tickets`에서 요소의 0번째가 현재 공항과 일치하면 해당 티켓을 사용하도록 했어요. 해당 티켓이 변경되는 것을 막기 위해서 복사본 배열을 만들었어요. 해당 티켓을 사용했으면 복사본 배열에서 제거하도록 했고, 제거된 배열의 1번째 인덱스 `to`를 다시 시작으로 탐색하는 dfs 탐색을 하도록 했어요. 
그리고 이 `tickets`가 다 없어지면 그제서야 `answer` 최종 배열에 경로를 넣어줬어요. 

이 최종 배열을 정렬한 후 가장 앞 요소를 반환했어요. 

### 3️⃣ 유기농 배추

원래 백준은 `function solution(~~) {}` 이렇게 형식을 만들어서 해결하려고 했지만 이 문제는 테스트케이스가 한 번에 묶여있어서 바로 순회했어요.

테스트케이스별로 순회하며 배추밭을 만들었어요. 주어진 input값을 배열에 넣고 배추가 심어진 곳을 1로 표시했어요. 
bfs를 통해서 배추를 심은 좌표를 탐색해서 방문하지 않은 곳을 방문 처리를 했어요.
배추밭을 순회해 1이고 방문하지 않은 곳에 지렁이를 풀고 bfs 탐색을 진행하도록 했어요. 
배추밭을 넘어가거나 배추가 심어지지 않은 곳이나 방문한 곳이라면 무시하도록 했어요. 

상하좌우로만 갈 수 있기에 `dx`, `dy` 좌표를 만들고 진행 방향대로 더해주는 방식으로 했어요.

### 4️⃣ 점프왕 쩰리

초기값은 모두 동일하게 (0, 0)부터 시작했어요.
bfs를 통해 각 좌표값을 가져와 다음 좌표를 계산했어요. 
맵을 벗어나지 않고 방문처리가 되어 있지 않은 곳에 방문하면 방문처리를 해주고 큐에 넣어줬어요.
최종 지점에 도착하면 bfs는 종료되고 `true` 값을 반환하고 bfs가 `true`라면 `HaruHaru` 아니라면 `Hing`을 반환하도록 했어요.

## 🔑 고민한 부분

### 2️⃣ 여행경로

최종적으로 경로를 `newPath`에 저장하고 마지막에 `answer`에 삽입하는 부분을 고민했던 것 같아요. 경로를 저장해두고 이를 마지막에 push하기 위해서는 현재 진행 중인 `tickets`의 길이가 0이면 최종값에 삽입해 반환할 수 있었어요. 
방문한 티켓의 도착 지점을 시작으로 다시 dfs하는 것이 키포인트인 것 같아요.

### 3️⃣ 유기농 배추

문제를 풀다 보니 `네트워크` 문제와 유사하다는 것을 느꼈어요. bfs로 해결했지만 bfs와 dfs는 정해진 방식이 있어서 이를 잘 익히면 주제가 달라도 비슷하게 적용하면 해결할 수 있다는 것을 느꼈어요❗ 

## 🤔 궁금한 점

- 리뷰어에게 궁금한 점이나 의견을 구하고 싶은 내용을 적어보아요.
