### PR TITLE
[김여진] 10주차 문제 풀이 제출합니다.

### DIFF
--- a/김여진/week10/[Lv2] 땅따먹기.js
+++ b/김여진/week10/[Lv2] 땅따먹기.js
@@ -1,0 +1,21 @@
+// 문제 접근
+// 1. 행단위로 얻을 수 있는 최대 점수를 기록하는 일차원 배열 dp 생성
+// 2. 행 수만큼 각 땅의 점수 + 이전 행에서 같은 열을 제외한 땅들의 최대 점수 (열이 달라야하니까)
+// 3. 마지막으로 dp의 최댓값 반환
+// 시간 복잡도 O(N)
+
+const solution = (land) => {
+  const n = land.length
+  let dp = [...land[0]];
+
+  for (let i = 1; i < n; i++) {
+    const prevDp = [...dp]; // 이전 행의 결과를 복사
+    dp[0] = land[i][0] + Math.max(prevDp[1], prevDp[2], prevDp[3]);
+    dp[1] = land[i][1] + Math.max(prevDp[0], prevDp[2], prevDp[3]);
+    dp[2] = land[i][2] + Math.max(prevDp[0], prevDp[1], prevDp[3]);
+    dp[3] = land[i][3] + Math.max(prevDp[0], prevDp[1], prevDp[2]);
+  }
+
+  return Math.max(...dp); 
+}
+

--- a/김여진/week10/[Lv3] 정수 삼각형.js
+++ b/김여진/week10/[Lv3] 정수 삼각형.js
@@ -1,0 +1,58 @@
+// 실패 풀이 - 시간 초과
+// 문제 접근
+// 1. 삼각형과 동일한 2차원 배열 dp를 만들어 0으로 채워놓음
+// 2. 각 행에서 이전 행의 같은 열, 왼쪽 열의 최댓값을 비교해 더함
+// 2. 마지막 행의 최댓값을 반환
+// 시간 복잡도 O(N*N)
+
+const solution = (triangle) => {
+  const n = triangle.length;
+  const dp = Array.from(Array(n), (_, i) => Array(i + 1).fill(0));
+
+  dp[0][0] = triangle[0][0];
+
+  for (let i = 1; i < n; i++) {
+    for (let j = 0; j <= i; j++) {
+      if (j === 0) { // 맨 왼쪽
+        dp[i][j] = dp[i - 1][j] + triangle[i][j];
+      } else if (j === i) { // 맨 오른쪽
+        dp[i][j] = dp[i - 1][j - 1] + triangle[i][j];
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j - 1], dp[i - 1][j]) + triangle[i][j];
+      }
+    }
+  }
+
+  return Math.max(...dp[n - 1]);
+};
+
+// 성공 풀이
+// 문제 접근
+// 1. 모든 삼각형을 반영하지 말고 삼각형의 행과 동일한 일차원 배열 dp 생성
+// 2. 이전dp의 같은 열, 왼쪽 열의 최댓값을 비교해 더함
+// 3. 이전dp를 현재dp로 업데이트
+// 2. 마지막 행의 최댓값을 반환
+// 시간 복잡도 O(N*N) 하지만 공간 복잡도를 O(N*N)에서 O(N)으로 줄임
+
+const solution = (triangle) => {
+  const n = triangle.length;
+  let prevDp = triangle[0]; 
+
+  for (let i = 1; i < n; i++) {
+    const currDp = Array(i + 1).fill(0);
+
+    for (let j = 0; j <= i; j++) {
+      if (j === 0) { // 맨 왼쪽
+        currDp[j] = prevDp[j] + triangle[i][j];
+      } else if (j === i) { // 맨 오른쪽
+        currDp[j] = prevDp[j - 1] + triangle[i][j];
+      } else { // 가운데
+        currDp[j] = Math.max(prevDp[j - 1], prevDp[j]) + triangle[i][j];
+      }
+    }
+
+    prevDp = currDp; 
+  }
+
+  return Math.max(...prevDp);
+};

--- a/김여진/week10/[Silver2] 가장 긴 감소하는 부분 수열.js
+++ b/김여진/week10/[Silver2] 가장 긴 감소하는 부분 수열.js
@@ -1,0 +1,28 @@
+// 문제 접근
+// 1. 일차원 dp를 만들어 1로 채워두고(그 수를 포함하는 감소하는 수열의 최소길이는 1) 
+// 2. 수열의 수가 그 앞 수보다 작으면(감소하면)
+// 현재 수로 끝나는 수열의 길이, 전의 작은 수로 끝나는 수열의 길이+1을 비교해 더 긴 걸 담음
+// 3. dp 중 최댓값 즉 가장 긴 수열 반환
+// 시간 복잡도 O(N*N)
+const fs = require("fs");
+const filePath = process.platform === "linux" ? "/dev/stdin" : "./example.txt";
+const input = fs.readFileSync(filePath).toString().trim().split("\n");
+
+const N = Number(input[0]);
+const nums = input[1].split(' ').map(Number);
+
+const solution = (nums) => {
+  const dp = Array(N).fill(1);
+
+  for (let i = 1; i < N; i++) {
+    for (let j = 0; j < i; j++) {
+      if (nums[i] < nums[j]) { 
+        dp[i] = Math.max(dp[i], dp[j] + 1);
+      }
+    }
+  }
+
+  return Math.max(...dp);
+};
+
+console.log(solution(nums));

--- a/김여진/week10/[Silver5] 다리 놓기.js
+++ b/김여진/week10/[Silver5] 다리 놓기.js
@@ -1,0 +1,36 @@
+// 문제 접근
+// 1. 30*30 2차원 배열 dp 생성해 0으로 채움
+// 2. n = 0, n = m일때는 경우의 수가 1이니까 이를 먼저 dp에 넣어주고
+// n이 1 ~ m-1 일때 파스칼 삼각형의 규칙을 사용해 dp를 업데이트
+// 3. 각 테스트 케이스에서 dp[m][n]의 값을 반환
+// 시간 복잡도 O(900)
+const fs = require("fs");
+const filePath = process.platform === "linux" ? "/dev/stdin" : "./example.txt";
+const input = fs.readFileSync(filePath).toString().trim().split("\n");
+
+const T = Number(input[0]);
+const testCases = input
+  .slice(1, T + 1)
+  .map((line) => line.split(" ").map(Number));
+
+const solution = (testCases) => {
+  const dp = Array.from(Array(30), () => Array(30).fill(0));
+
+  for (let m = 1; m < 30; m++) {
+    dp[m][0] = 1; // n = 0일 때 경우의 수는 1
+    dp[m][m] = 1; // n = m일 때 경우의 수는 1
+    
+    for (let n = 1; n < m; n++) {
+      dp[m][n] = dp[m - 1][n - 1] + dp[m - 1][n];
+    }
+  }
+
+  const results = [];
+  for (const [n, m] of testCases) {
+    results.push(dp[m][n]);
+  }
+
+  return results;
+};
+
+console.log(solution(testCases).join('\n'));


### PR DESCRIPTION
## 💡 풀이한 문제

- [땅따먹기](https://school.programmers.co.kr/learn/courses/30/lessons/12913)
- [정수 삼각형](https://school.programmers.co.kr/learn/courses/30/lessons/43105)
- [다리 놓기](https://www.acmicpc.net/problem/1010)
- [가장 긴 감소하는 부분 수열](https://www.acmicpc.net/problem/11722)

## 📌 접근 방식

### 1️⃣ 땅따먹기

dp에 각 열에서 얻을 수 있는 최대 점수를 넣어 마지막에 dp의 최댓값을 구하면 된다 생각했어요.

먼저 land의 첫번째 행을 복사해 dp를 만들고
i=1 행부터 각 열의 땅의 점수와 이전 행(dp)의 그 특정 열을 제외한 최댓값을 구해 각 열을 업데이트 하는 식으로 열이 겹치지 않게 했어요.

마지막으로 dp 배열의 최댓값을 반환했어요.

### 2️⃣ 정수 삼각형

삼각형의 행과 동일한 일차원 배열 dp를 생성했어요.
이전dp의 같은 열, 왼쪽 열의 최댓값을 비교해 더해 만들어진 dp를 이전dp에 대입해 업데이트해줬어요.
마지막으로 행의 최댓값을 반환했어요.

### 3️⃣ 다리 놓기

30*30 2차원 배열 dp를 생성해 0으로 채워놨어요.
파스칼 삼각형 규칙을 사용해 n, m에 따른 경우의 수를 dp에 넣어줬어요.
n = 0, n = m일때는 경우의 수가 1이니까 이를 먼저 dp에 넣어주고
n이 1 ~ m-1 일때 dp를 업데이트했어요.
마지막으로 각 테스트 케이스에서 dp[m][n]의 값을 반환했어요.

### 4️⃣ 가장 긴 감소하는 부분 수열

일차원 dp를 만들어 1로 채워두고(그 수를 포함하는 감소하는 수열의 최소길이는 1) 
수열을 탐색하며 수열의 수가 그 앞 수보다 작으면(감소하면)
현재 수로 끝나는 수열의 길이, 전의 작은 수로 끝나는 수열의 길이+1을 비교해 더 긴 걸 담았어요.
마지막으로 dp 중 최댓값, 즉 가장 긴 수열을 반환했어요.

## 🔑 고민한 부분

### 2️⃣ 정수 삼각형

처음엔
삼각형과 동일한 2차원 배열 dp를 만들어 0으로 채워놓고
각 행에서 이전 행의 같은 열, 왼쪽 열을 비교해 더했어요. 이런 식으로 최댓값이 쌓이게 돼요.
그리고 마지막 행의 최댓값을 반환했어요.

그런데 시간초과가 뜨더라고요.
막연하게 삼각형이면 2차원 배열로 최댓값을 넣어야지~ 했는데
일차원 배열을 사용하며 업데이트할 수도 있겠더라고요.

그래서 모든 삼각형을 반영하지 말고 삼각형의 행과 동일한 일차원 배열 dp 생성했어요.
그리고 마찬가지로 최댓값이 쌓이게 하며 현재dp를 만들고
이전dp를 현재dp로 업데이트했어요
시간 복잡도는 모든 원소를 한 번씩 방문하니 O(N*N) 로 동일하지만 공간 복잡도를 O(N*N)에서 O(N)으로 줄일 수 있었어요.

## 🤔 궁금한 점
